### PR TITLE
SVCPLAN-626: Lustre client tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ profile_lustre::bindmounts::map:
 ...
 ```
 
+Tunings can be applied like this:
+
+```
+profile_lustre::tuning::params:
+  "osc.*.max_pages_per_rpc": "4096"
+  "osc.*.max_rpcs_in_flight": "16"
+  "osc.*.max_dirty_mb": "512"
+  "osc.*.checksums": "0"
+...
+```
+
+Recommendations and/or defaults TBD.
+
+
 ## Dependencies
 
 n/a

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -14,6 +14,7 @@
 * [`profile_lustre::module`](#profile_lustremodule): Configure and build lnet & lustre kernel modules
 * [`profile_lustre::nativemounts`](#profile_lustrenativemounts): Mount Lustre filesystems on the client
 * [`profile_lustre::service`](#profile_lustreservice): Configure the lnet service
+* [`profile_lustre::tuning`](#profile_lustretuning): Apply Lustre tuning parameters using lctl.
 
 ### Defined types
 
@@ -289,6 +290,34 @@ String of the name of the lnet service
 Data type: `Boolean`
 
 Boolean to determine if the lnet service is ensured running
+
+### <a name="profile_lustretuning"></a>`profile_lustre::tuning`
+
+Apply Lustre tuning parameters using lctl.
+
+#### Examples
+
+##### 
+
+```puppet
+include profile_lustre::tuning
+```
+
+#### Parameters
+
+The following parameters are available in the `profile_lustre::tuning` class:
+
+* [`params`](#params)
+
+##### <a name="params"></a>`params`
+
+Data type: `Hash`
+
+Hash of tuning parameters:
+  "<key1>": "<value1>"
+  "<key2>": "<value2">
+Note: Keys may contain * as a wildcard. E.g.:
+  "osc.*.max_pages_per_rpc": "4096"
 
 ## Defined types
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -40,3 +40,5 @@ profile_lustre::module::remote_networks: {}
 profile_lustre::service::lnet_service_enabled: false
 profile_lustre::service::lnet_service_name: "lnet"
 profile_lustre::service::lnet_service_running: false
+
+profile_lustre::tuning::params: {}

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -12,5 +12,8 @@ class profile_lustre::client {
   include ::profile_lustre::module
   include ::profile_lustre::nativemounts
   include ::profile_lustre::service
+  include ::profile_lustre::tuning
+
+  Class['::profile_lustre::nativemounts'] -> Class['::profile_lustre::tuning']
 
 }

--- a/manifests/lnet_router.pp
+++ b/manifests/lnet_router.pp
@@ -10,5 +10,8 @@ class profile_lustre::lnet_router {
   include ::profile_lustre::install
   include ::profile_lustre::module
   include ::profile_lustre::service
+  include ::profile_lustre::tuning
+
+  Class['::profile_lustre::module'] -> Class['::profile_lustre::tuning']
 
 }

--- a/manifests/tuning.pp
+++ b/manifests/tuning.pp
@@ -1,0 +1,29 @@
+# @summary Apply Lustre tuning parameters using lctl.
+#
+# Apply Lustre tuning parameters using lctl.
+#
+# @param params
+#   Hash of tuning parameters:
+#     "<key1>": "<value1>"
+#     "<key2>": "<value2">
+#   Note: Keys may contain * as a wildcard. E.g.:
+#     "osc.*.max_pages_per_rpc": "4096"
+#
+# @example
+#   include profile_lustre::tuning
+class profile_lustre::tuning (
+  Hash $params,
+) {
+
+  $params.each | String $param, String $value | {
+    $check_param_command = "lctl get_param -n ${param} | egrep -qv \"^${value}$\""
+    $set_param_command = "lctl set_param ${param}=${value}"
+    exec { $param:
+      command => $set_param_command,
+      onlyif  => $check_param_command,
+      path    => ['/usr/bin', '/usr/sbin', '/sbin'],
+    }
+
+  }
+
+}

--- a/spec/classes/tuning_spec.rb
+++ b/spec/classes/tuning_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile_lustre::tuning' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end


### PR DESCRIPTION
create tuning class with {} data, included by both client and lnet_router classes