### PR TITLE
Rundall/svc 20542/default data no bindmounts

### DIFF
--- a/manifests/bindmounts.pp
+++ b/manifests/bindmounts.pp
@@ -18,8 +18,10 @@ class profile_lustre::bindmounts (
   Optional[ Hash ] $map = undef,
 ) {
 
-  $map.each | $k, $v | {
-    profile_lustre::bindmount_resource { $k: * => $v }
+  if $map {
+    $map.each | $k, $v | {
+      profile_lustre::bindmount_resource { $k: * => $v }
+    }
   }
 
 }


### PR DESCRIPTION
profile_lustre::bindmounts: 
- add conditional so that there is no error if map is left undef (i.e.,
  allow no bindmounts)