### PR TITLE
SVCPLAN-1554: separate trigger file for LNet config

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -171,6 +171,7 @@ The following parameters are available in the `profile_lustre::module` class:
 
 * [`is_lnet_router`](#is_lnet_router)
 * [`lnet_conf_file`](#lnet_conf_file)
+* [`lnet_trigger_file`](#lnet_trigger_file)
 * [`local_networks`](#local_networks)
 * [`modprobe_lustre_conf_file`](#modprobe_lustre_conf_file)
 * [`remote_networks`](#remote_networks)
@@ -186,6 +187,13 @@ Is the node an LNet router or not?
 Data type: `String`
 
 Full path to lnet.conf file, e.g. "/etc/lnet.conf"
+
+##### <a name="lnet_trigger_file"></a>`lnet_trigger_file`
+
+Data type: `String`
+
+Full path to LNet trigger file (if this file is NOT present,
+Puppet will (re)configure Lnet).
 
 ##### <a name="local_networks"></a>`local_networks`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -17,6 +17,7 @@ profile_lustre::firewall::sources:
 
 profile_lustre::module::is_lnet_router: false
 profile_lustre::module::lnet_conf_file: "/etc/lnet.conf"
+profile_lustre::module::lnet_trigger_file: "/etc/lnet.trigger"
 # EXAMPLE LOCAL_NETWORKS DATA
 # profile_lustre::module::local_networks:
 #   tcp0:


### PR DESCRIPTION
Create $lnet_trigger_file — LNet will only be (re)configured if this file
is missing. Use this instead of $lnet_conf_file.

Solves issue where LNet was not brought up and running w/o deleting the
original trigger file, $lnet_conf_file, which is installed by the
lustre-client RPM.