### PR TITLE
SVCPLAN-2550: Issue with module ordering

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -75,6 +75,7 @@ class profile_lustre::module (
     unless  => "test -f ${lnet_trigger_file}",
     path    => ['/usr/bin', '/usr/sbin', '/sbin'],
     require => [
+      File[ $modprobe_lustre_conf_file ],
       Package[ $profile_lustre::install::required_pkgs ],
     ],
   }
@@ -86,6 +87,7 @@ class profile_lustre::module (
       path      => ['/usr/bin', '/usr/sbin', '/sbin'],
       subscribe => Exec['configure_lustre'],
       require   => [
+        File[ $modprobe_lustre_conf_file ],
         Package[ $profile_lustre::install::required_pkgs ],
       ],
     }


### PR DESCRIPTION
Fix #8. 
This issue came up in setting up a new cluster. Unclear why it hadn't been an issue before.

See https://jira.ncsa.illinois.edu/browse/SVCPLAN-2550

This is being tested on `mgtest02`.