### PR TITLE
jhaney/SVCPLAN-1629/monitor-lnet-router-stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,35 @@ Recommendations and/or defaults TBD.
 
 ### Telegraf Monitoring
 
+#### Lustre Router Stats
+Can use telegraf to monitor lustre router stats
+
+To enable/disable set:
+```yaml
+profile_lustre::telegraf::lnet_router_stats::enabled: true
+```
+
+Some configuration must be done for telegraf monitoring to work. This configuration is handled with the `profile_lustre::telegraf::lnet_router_stats::script_cfg` hash
+
+Example:
+```
+#For a lustre CLIENT system with these mounts
+[root@hli-cn09 ~]# findmnt -t lustre
+TARGET    SOURCE
+/storage  192.168.1.2@o2ib,192.168.1.3@o2ib:192.168.1.4@o2ib,192.168.1.5@o2ib:192.168.1.6@o2ib,192.168.1.7@o2ib:192.168.1.8@o2ib,192.168.1.9@o2ib:/storage
+/projects 192.168.1.2@o2ib,192.168.1.3@o2ib:192.168.1.4@o2ib,192.168.1.5@o2ib:192.168.1.6@o2ib,192.168.1.7@o2ib:192.168.1.8@o2ib,192.168.1.9@o2ib:/storage[/nsf/prg]
+```
+
+You can use a config like this:
+
+```yaml
+profile_lustre::telegraf::lnet_router_stats::script_cfg:
+  # Array of Lustre filesystem(s)
+  fs:
+    - "storage"
+```
+
+#### Lustre Client Health
 Can use telegraf to monitor lustre client health
 
 To enable/disable set:
@@ -170,6 +199,7 @@ profile_lustre::telegraf::lustre_client_health::script_cfg:
 
 * https://github.com/ncsa/puppet-telegraf
 * https://github.com/ncsa/puppet-profile_monitoring
+* https://forge.puppet.com/modules/saz/sudo
 
 ## Reference
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -300,6 +300,51 @@ Data type: `Boolean`
 
 Boolean to determine if the lnet service is ensured running
 
+### <a name="profile_lustretelegraflnet_router"></a>`profile_lustre::telegraf::lnet_router_stats`
+
+Telegraf Lustre router stat checks
+
+#### Examples
+
+##### 
+
+```puppet
+include profile_lustre::telegraf::lnet_router_stats
+```
+
+#### Parameters
+
+The following parameters are available in the `profile_lustre::telegraf::lnet_router_stats` class:
+
+* [`enabled`](#enabled)
+* [`script_cfg`](#script_cfg)
+* [`sudo_cfg`](#sudo_cfg)
+* [`telegraf_cfg`](#telegraf_cfg)
+
+##### <a name="enabled"></a>`enabled`
+
+Data type: `Boolean`
+
+Enable or disable this health check
+
+##### <a name="script_cfg"></a>`script_cfg`
+
+Data type: `Hash`
+
+Hash that controls the values for the script config file. See data/common.yaml for examples
+
+##### <a name="sudo_cfg"></a>`sudo_cfg`
+
+Data type: `String`
+
+String setting sudo config for this lustre check
+
+##### <a name="telegraf_cfg"></a>`telegraf_cfg`
+
+Data type: `Hash`
+
+Hash of key:value pairs passed to telegraf::input as options
+
 ### <a name="profile_lustretelegraflustre_client_health"></a>`profile_lustre::telegraf::lustre_client_health`
 
 Telegraf Lustre client health checks

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -42,6 +42,19 @@ profile_lustre::service::lnet_service_enabled: false
 profile_lustre::service::lnet_service_name: "lnet"
 profile_lustre::service::lnet_service_running: false
 
+profile_lustre::telegraf::lnet_router_stats::enabled: true
+profile_lustre::telegraf::lnet_router_stats::script_cfg:
+  # Array of Lustre filesystem(s)
+  fs: []
+profile_lustre::telegraf::lnet_router_stats::sudo_cfg: |
+  Defaults:telegraf !mail_always
+  Defaults:telegraf !requiretty
+  telegraf ALL = NOPASSWD: NOMAIL: /usr/sbin/lnetctl *
+profile_lustre::telegraf::lnet_router_stats::telegraf_cfg:
+  data_format: "influx"
+  interval: "1m"
+  timeout: "30s"
+
 profile_lustre::telegraf::lustre_client_health::enabled: true
 profile_lustre::telegraf::lustre_client_health::script_cfg:
   # Array of Mount Paths eg. "/taiga"

--- a/manifests/lnet_router.pp
+++ b/manifests/lnet_router.pp
@@ -10,6 +10,7 @@ class profile_lustre::lnet_router {
   include ::profile_lustre::install
   include ::profile_lustre::module
   include ::profile_lustre::service
+  include ::profile_lustre::telegraf::lnet_router_stats
   include ::profile_lustre::tuning
 
   Class['::profile_lustre::module'] -> Class['::profile_lustre::tuning']

--- a/manifests/telegraf/lnet_router_stats.pp
+++ b/manifests/telegraf/lnet_router_stats.pp
@@ -1,0 +1,98 @@
+# @summary Telegraf LNET router stats
+#
+# @param enabled
+#   Enable or disable this health check
+#
+# @param script_cfg
+#   Hash that controls the values for the script config file. See data/common.yaml for examples
+#
+# @param sudo_cfg
+#   String setting sudo config for this lustre check
+#
+# @param telegraf_cfg
+#   Hash of key:value pairs passed to telegraf::input as options
+#
+# @example
+#   include profile_lustre::telegraf::lnet_router_stats
+class profile_lustre::telegraf::lnet_router_stats (
+  Boolean $enabled,
+  Hash    $script_cfg,
+  String  $sudo_cfg,
+  Hash    $telegraf_cfg,
+){
+
+  #
+  # Checks specific for this particular telegraf script
+  #
+  if ($enabled) and ($::profile_monitoring::telegraf::enabled) {
+    $script_cfg.each | $cfg_parm, $cfg_parm_value | {
+      if empty($cfg_parm_value) {
+        notify { "WARNING: ${cfg_parm} is not set, so it not being monitored" : }
+      }
+    }
+  }
+
+  #
+  # Templatized telegraf script with config
+  #
+  $script_base_name = 'lnet_router_stats'
+  $script_path = '/etc/telegraf/scripts/lustre'
+  $script_extension = '.sh'
+  $script_full_path = "${script_path}/${script_base_name}${script_extension}"
+  $script_cfg_full_path = "${script_path}/${script_base_name}_config"
+
+  include profile_monitoring::telegraf
+  include ::telegraf
+
+  if ($enabled) and ($::profile_monitoring::telegraf::enabled) {
+    $ensure_parm = 'present'
+  } else {
+    $ensure_parm = 'absent'
+  }
+
+  # Create folder for telegraf lustre scripts
+  $script_dir_defaults = {
+    ensure => 'directory',
+    owner  => 'root',
+    group  => 'telegraf',
+    mode   => '0750',
+  }
+  ensure_resource('file', $script_path , $script_dir_defaults)
+
+  # Setup telegraf config
+  $telegraf_cfg_final = $telegraf_cfg + { 'command' => $script_full_path }
+  telegraf::input { $script_base_name :
+    ensure      => $ensure_parm,
+    plugin_type => 'exec',
+    options     => [ $telegraf_cfg_final ],
+    require     => File[$script_full_path],
+  }
+
+  # Setup the actual script
+  $script_defaults = { source_path => $script_cfg_full_path,  }
+  file { $script_full_path :
+    ensure  => $ensure_parm,
+    content => epp("${module_name}/${script_base_name}${script_extension}.epp", $script_defaults),
+    mode    => '0750',
+    owner   => 'root',
+    group   => 'telegraf',
+  }
+
+  # Setup the scripts config file
+  file { $script_cfg_full_path :
+    ensure  => $ensure_parm,
+    content => epp("${module_name}/${script_base_name}_config.epp", $script_cfg),
+    owner   => 'root',
+    group   => 'telegraf',
+    mode    => '0640',
+  }
+
+  #
+  # Sudo config specific for this profile
+  #
+  sudo::conf { 'telegraf_lustre_check':
+    ensure   => $ensure_parm,
+    priority => 10,
+    content  => $sudo_cfg,
+  }
+}

--- a/spec/classes/telegraf/lnet_router_stats.rb
+++ b/spec/classes/telegraf/lnet_router_stats.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile_lustre::telegraf::lnet_router_stats' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/templates/lnet_router_stats.sh.epp
+++ b/templates/lnet_router_stats.sh.epp
@@ -1,0 +1,10 @@
+<%- | $source_path,
+| -%>
+#!/bin/bash
+# This file is managed by Puppet
+
+source <%= $source_path %>
+
+stats_line=$(sudo /usr/sbin/lnetctl stats show | sed 's/:\ /=/' | tail -n +2 | xargs | sed 's/\ /,/g')
+
+echo "lnet_stats,fs=${fs} ${stats_line}"

--- a/templates/lnet_router_stats_config.epp
+++ b/templates/lnet_router_stats_config.epp
@@ -1,0 +1,8 @@
+<%- | $fs
+| -%>
+# This file is managed by Puppet
+
+##Lustre Telegraf Config
+##
+
+readonly fs="<%= $fs.join(' ') %>" ## List of Mount Paths space separated eg. "/taiga /ngale"


### PR DESCRIPTION
Adding telegraf monitoring check for LNET Routers stats

~Will stay as draft until verified on a system.~ This has been verified on the secondary LNET Router for HOLL-I

The pdk-validate build failure is a known issue that shouldn't halt this PR's approval