### PR TITLE
SVCPLAN-5555: Add support for SUSE

### DIFF
--- a/data/os/Suse.yaml
+++ b/data/os/Suse.yaml
@@ -1,0 +1,5 @@
+---
+profile_lustre::install::required_pkgs:
+  - "kmod-lustre-client"
+  - "lustre-client"
+profile_lustre::install::yumrepo: {}

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,11 +12,13 @@ class profile_lustre::install (
   Array[String] $required_pkgs,
   Hash            $yumrepo,
 ) {
-  $yumrepo_defaults = {
-    ensure  => present,
-    enabled => true,
+  if ( ! empty( $yumrepo ) ) {
+    $yumrepo_defaults = {
+      ensure  => present,
+      enabled => true,
+    }
+    ensure_resources( 'yumrepo', $yumrepo, $yumrepo_defaults )
   }
-  ensure_resources( 'yumrepo', $yumrepo, $yumrepo_defaults )
 
   $packages_defaults = {
   }

--- a/metadata.json
+++ b/metadata.json
@@ -37,7 +37,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.21.0 < 8.0.0"
+      "version_requirement": ">= 6.21.0 < 9.0.0"
     }
   ],
   "pdk-version": "3.0.1",


### PR DESCRIPTION
We do not currently have a place to test these changes.

It is unclear to me how we manage repos in SUSE. For now I've just removed the repo management from SUSE hosts. 
Likely in clusters the 2 lustre packages would already be installed in the boot image. 